### PR TITLE
Remove global emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ register().then(() => {
 
 ```
 
+### Logging
+
+Log output is done via [`debug`](https://github.com/visionmedia/debug).
+
+Namespaces are as follows:
+
+- `swf:polling` - Related to long-polling operations (for decision and activity tasks).
+- `swf:registration` - Related to registering workflows and activities with AWS.
+- `swf:decider:<workflowId>:<runId>` - For decision task execution.
+- `swf:activity:<ActivityTaskName>:<workflowId>:<activityId>` - For activity task + execution.
+
+**You should run with your `DEBUG` environment variable set to at least `swf:*` so you see error messages.**
+
 ## Public API
 
 <a name="api-init"></a>
@@ -185,15 +198,6 @@ _TODO: Support other kinds of events._
 | `type`       | `String` | `"signal"`  |
 | `signalName` | `String` |             |
 | `input`      | `String` |             |
-
-## Logging
-
-Logging is done via [`debug`](https://github.com/visionmedia/debug).
-
-Namespaces are as follows:
-
-- `swf:<workflowId>:decider` - For decision task polling + execution.
-- `swf:<workflowId>:<ActivityTaskName>:<activityId>` - For activity task polling + execution.
 
 ### Representing Errors
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Or, in JS:
 const AWS = require('aws-sdk');
 const { init } = require('worky-mcworkflowface');
 const {
-    on,
     register,
     startActivityTaskPoller,
     startDecisionTaskPoller,
@@ -33,10 +32,6 @@ const {
     taskList: 'MainTaskList',
     workflowDefinitions: require('./workflows'),
     activityTaskDefinitions: require('./activities'),
-});
-
-on('error', (err) => {
-    console.error(err);
 });
 
 register().then(() => {
@@ -66,21 +61,11 @@ Available options:
 
 |                     Method                     |                                                     Description                                                      |
 |------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `on()`                                         | A standard `EventEmitter.on()` method used to listen for events.                                                     |
 | `register()`                                   | Registers your workflows and activity tasks with SWF. Returns a `Promise` that resolves when registration completes. |
 | `resolveActivityTaskDefinition(name, version)` | Resolves a specific name + version combo of an activity task.                                                                                                                     |
 | `resolveWorkflowDefinition(name, version)`     | Resolves a specific name + version combo of a decision task.                                                                                                                     |
 | `startActivityTaskPoller()`                    | Starts polling for and executing SWF Activity Tasks.                                                                 |
 | `startDecisionTaskPoller()`                    | Starts polling for and executing SWF Decision Tasks.                                                                 |
-
-Any errors encountered during polling and execution will be emitted as `error` events. You can trap them like so:
-
-```javascript
-const { on } = init(options);
-on('error', (err) => {
-    console.error('oh noes!', err);
-});
-```
 
 ## Deciders
 

--- a/src/activity_task_runner/index.js
+++ b/src/activity_task_runner/index.js
@@ -1,5 +1,5 @@
 const debug = require('debug');
-const log = debug('swf');
+const pollingLog = debug('swf:polling');
 
 const { createTaskPoller } = require('../util/poller');
 
@@ -32,9 +32,9 @@ function pollForAndRunActivityTasks({
         },
     });
 
-    poller.on('started', () => log('Polling for activity tasks...'));
+    poller.on('started', () => pollingLog('Polling for activity tasks...'));
 
-    poller.on('timedOut', () => log('Activity task long polling timed out.'));
+    poller.on('timedOut', () => pollingLog('Activity task long polling timed out.'));
 
     poller.on('task', (task, continuePolling) => {
         // Logging is done in the context of a task being executed
@@ -44,7 +44,7 @@ function pollForAndRunActivityTasks({
             activityType: { name },
         } = task;
 
-        const workflowLog = debug(`swf:${workflowId}:${name}:${activityId}`);
+        const workflowLog = debug(`swf:actvity:${name}:${workflowId}:${activityId}`);
         workflowLog('Received activity task');
 
         resolveActivityTaskFunction(task, activityTaskDefinitions)
@@ -54,8 +54,8 @@ function pollForAndRunActivityTasks({
             })
             .then(
                 // NOTE: Both of these responders *never* reject, they only resolve.
-                createActivitySuccessResponder(swfClient, task.taskToken, log, workflowLog),
-                createActivityFailureResponder(swfClient, task.taskToken, log, workflowLog)
+                createActivitySuccessResponder(swfClient, task.taskToken, workflowLog),
+                createActivityFailureResponder(swfClient, task.taskToken, workflowLog)
             )
             .then(continuePolling);
     });

--- a/src/decision_task_runner/index.js
+++ b/src/decision_task_runner/index.js
@@ -1,5 +1,5 @@
 const debug = require('debug');
-const log = debug('swf');
+const pollingLog = debug('swf:polling');
 
 const { createTaskPoller } = require('../util/poller');
 
@@ -44,17 +44,17 @@ function pollForAndRunDecisionTasks(options) {
         },
     });
 
-    poller.on('started', () => log('Polling for decision tasks...'));
+    poller.on('started', () => pollingLog('Polling for decision tasks...'));
 
-    poller.on('timedOut', () => log('Decision task long polling timed out.'));
+    poller.on('timedOut', () => pollingLog('Decision task long polling timed out.'));
 
     poller.on('task', (task, continuePolling) => {
         const {
             events,
-            workflowExecution: { workflowId },
+            workflowExecution: { workflowId, runId },
         } = task;
 
-        const workflowLog = debug(`swf:${workflowId}:decider`);
+        const workflowLog = debug(`swf:decider:${workflowId}:${runId}`);
 
         const handleCompletedDecisionTask = createDecisionTaskCompletedResponder(
             swfClient,

--- a/src/decision_task_runner/index.js
+++ b/src/decision_task_runner/index.js
@@ -5,11 +5,10 @@ const { createTaskPoller } = require('../util/poller');
 
 const { resolveDeciderFunction } = require('./resolve');
 const { runDecider } = require('./run');
-const { createDecisionTaskCompletedResponder } = require('./respond');
 const {
-    summarizeDecisions,
-    summarizeError,
-} = require('../util/logging');
+    createDecisionTaskCompletedResponder,
+    createDecisionTaskFailureResponder,
+} = require('./respond');
 
 function getMostRecentNonDecisionEvent(events) {
     const rx = /^Decision/;
@@ -27,7 +26,6 @@ function getMostRecentNonDecisionEvent(events) {
 function pollForAndRunDecisionTasks(options) {
     const {
         domain,
-        emitter,
         identity,
         swfClient,
         taskList,
@@ -46,9 +44,6 @@ function pollForAndRunDecisionTasks(options) {
         },
     });
 
-    // Forward polling errors to the main emitter.
-    poller.on('error', (err) => emitter.emit('error', err));
-
     poller.on('started', () => log('Polling for decision tasks...'));
 
     poller.on('timedOut', () => log('Decision task long polling timed out.'));
@@ -61,37 +56,32 @@ function pollForAndRunDecisionTasks(options) {
 
         const workflowLog = debug(`swf:${workflowId}:decider`);
 
-        const mostRecentEvent = getMostRecentNonDecisionEvent(events) || {};
-
-        workflowLog(
-            'Received decision task with %d event(s). Most recent non-decision event: %s (%s)',
-            events.length,
-            mostRecentEvent.eventType,
-            mostRecentEvent.eventId
-        );
-
         const handleCompletedDecisionTask = createDecisionTaskCompletedResponder(
             swfClient,
             task,
-            emitter
+            workflowLog
         );
+
+        const handleFailedDecisionTask = createDecisionTaskFailureResponder(
+            swfClient,
+            task,
+            workflowLog
+        );
+
+        if (workflowLog.enabled) {
+            const mostRecentEvent = getMostRecentNonDecisionEvent(events) || {};
+            workflowLog(
+                'Received decision task with %d event(s). Most recent non-decision event: %s (%s)',
+                events.length,
+                mostRecentEvent.eventType,
+                mostRecentEvent.eventId
+            );
+        }
 
         resolveDeciderFunction(task, workflowDefinitions)
             .then(deciderFunc => runDecider(task, deciderFunc, workflowLog, options))
-            .then(handleCompletedDecisionTask)
-            .then((decisions) => {
-                workflowLog(
-                    'Decision task completed: %s',
-                    decisions.length ? summarizeDecisions(decisions) : '(no decisions)'
-                );
-                continuePolling();
-            })
-            .catch(err => {
-                if (workflowLog.enabled !== false) {
-                    workflowLog('Decision task failed: %s', summarizeError(err));
-                }
-                continuePolling();
-            });
+            .then(handleCompletedDecisionTask, handleFailedDecisionTask)
+            .then(continuePolling);
     });
 
     poller.start();

--- a/src/decision_task_runner/respond.js
+++ b/src/decision_task_runner/respond.js
@@ -1,20 +1,45 @@
+const {
+    summarizeDecisions,
+    summarizeError,
+} = require('../util/logging');
+
+/**
+ * Returns a function that logs a decision task failure.
+ */
+function createDecisionTaskFailureResponder(swfClient, task, log) {
+    return function decisionTaskFailureResponder(err) {
+        // NOTE: There's no `respondDecisionTaskFailed()` API. When decision tasks fail, they just
+        //       time out and are retried.
+        if (log.enabled) {
+            log('Decision task failed: %s', summarizeError(err));
+        }
+    };
+}
+
 /**
  * Returns a function that can be used to mark a decision task as complete.
  */
-function createDecisionTaskCompletedResponder(swfClient, task, emitter) {
+function createDecisionTaskCompletedResponder(swfClient, task, log) {
     return function decisionTaskCompleteResponder(decisions) {
+        if (log.enabled) {
+            log(
+                'Decision task completed: %s',
+                decisions.length ? summarizeDecisions(decisions) : '(no decisions)'
+            );
+        }
+
         const params = {
             taskToken: task.taskToken,
             decisions,
         };
-        return new Promise((resolve, reject) => {
+
+        return new Promise((resolve) => {
             swfClient.respondDecisionTaskCompleted(params, (err) => {
-                if (err) {
-                    emitter.emit('error', err);
-                    reject(err);
-                    return;
+                if (err && log.enabled) {
+                    log('Error during respondDecisionTaskCompleted: %s', summarizeError(err));
                 }
-                resolve(decisions);
+
+                resolve();
             });
         });
     };
@@ -22,4 +47,5 @@ function createDecisionTaskCompletedResponder(swfClient, task, emitter) {
 
 module.exports = {
     createDecisionTaskCompletedResponder,
+    createDecisionTaskFailureResponder,
 };

--- a/src/init.js
+++ b/src/init.js
@@ -1,4 +1,3 @@
-const { EventEmitter } = require('events');
 const os = require('os');
 
 const { registerWithSwf } = require('./register');
@@ -8,17 +7,13 @@ const { normalizeNameAndVersion } = require('./util/name_and_version');
 const { resolveNameAndVersion } = require('./util/version_resolution');
 
 function init(options) {
-    const emitter = new EventEmitter();
     const effectiveOptions = Object.assign(
         {
             activityTaskDefitions: [],
             identity: os.hostname(),
             workflowDefinitions: [],
         },
-        options || {},
-        {
-            emitter,
-        }
+        options || {}
     );
 
     if (typeof options.swfClient !== 'object') {
@@ -26,11 +21,7 @@ function init(options) {
     }
 
     function register() {
-        return registerWithSwf(effectiveOptions).catch(err => {
-            // Allow consuming error via emitter or Promise.
-            emitter.emit('error', err);
-            throw err;
-        });
+        return registerWithSwf(effectiveOptions);
     }
 
     function resolveActivityTaskDefinition(name, version) {
@@ -55,10 +46,7 @@ function init(options) {
         return pollForAndRunDecisionTasks(effectiveOptions);
     }
 
-    const on = emitter.on.bind(emitter);
-
     return {
-        on,
         register,
         resolveActivityTaskDefinition,
         resolveWorkflowDefinition,

--- a/src/register.js
+++ b/src/register.js
@@ -1,6 +1,6 @@
 const compareVersions = require('node-version-compare');
 
-const log = require('debug')('swf');
+const log = require('debug')('swf:registration');
 
 const DEFAULT_ACTIVITY_TASK_SETTINGS = {
     defaultTaskStartToCloseTimeout: 'NONE',


### PR DESCRIPTION
- Remove `on()` from functions returned by `init()`
- Organize debug-based logging a little more

The idea here is that since we're doing a lot of logging anyway (using debug), awkwardly exposing an event emitter for error logging is redundant (and kind of confusing).

This is a breaking change, users will need to update not to use `on()`.