### PR TITLE
🤔  Rethink dealing with unrecognized events

### DIFF
--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,32 +1,17 @@
 const itemHandlers = require('./types');
 const debug = require('debug');
 
-const unhandledEventsSeenAt = {};
-const UNHANDLED_EVENT_REPORTING_INTERVAL = 60 * 1000 * 3;
-
 function logUnhandledEvent(event) {
-    const lastSeenAt = unhandledEventsSeenAt[event.eventType] || 0;
-
-    const now = Date.now();
-    const msSinceLastLog = now - lastSeenAt;
-
-    if (msSinceLastLog < UNHANDLED_EVENT_REPORTING_INTERVAL) {
-        // We've already logged about this recently.
-        return false;
-    }
-
-    unhandledEventsSeenAt[event.eventType] = now;
-
     const log = debug('swf:unhandled-events');
+
     if (!log.enabled) {
-        return false;
+        return;
     }
 
     log(
         'Unhandled SWF Event: %s',
         JSON.stringify(event, null, 4)
     );
-    return true;
 }
 
 /**
@@ -35,7 +20,9 @@ function logUnhandledEvent(event) {
  * @return {Array} Array of Workflow Items.
  */
 function distillEventsIntoItems(rawEvents) {
-    const state = {};
+    const state = {
+        unhandledEvents: [],
+    };
     const items = [];
 
     rawEvents.forEach((event) => {
@@ -49,9 +36,36 @@ function distillEventsIntoItems(rawEvents) {
         });
 
         if (!handled) {
-            logUnhandledEvent(event);
+            // Track unhandled events. DecisionTaskCompleted and
+            // DecisionTaskTimedOut events will clear this flag, ensure that we
+            // only crash once per decider run.
+            state.unhandledEvents.push(event);
         }
     });
+
+    const { unhandledEvents } = state;
+    if (unhandledEvents.length) {
+        // This is bad. Somehow, this amazing library is not built to handle
+        // all the crazy events SWF can throw at us.
+        // Most of the time, these will happen as a result of:
+        //
+        //   - Incorrect AWS permissions
+        //   - AWS rate limiting
+        //   - Decider bugs
+        //
+        // We handle this by throwing when the event is *first* encountered
+        // (which will crash the decider and lead to DecisionTaskTimedOut
+        // events). Subsequent decider runs will ignore the unhandled event.
+        //
+        // Hopefully, if workflow and decider timeouts are set up, this
+        // will work as a defacto rate limiter.
+        unhandledEvents.forEach(logUnhandledEvent);
+
+        const eventTypes = unhandledEvents.map(event => event.eventType);
+        const err = new Error(`Unhandled SWF event(s): ${eventTypes.join(', ')}`);
+        err.code = 'EUNHANDLEDEVENT';
+        throw err;
+    }
 
     return items;
 }

--- a/src/events/types/activity.js
+++ b/src/events/types/activity.js
@@ -2,24 +2,6 @@
 const JSONish = require('../../util/jsonish');
 
 module.exports = {
-    ScheduleActivityTaskFailed(event, state, items) {
-        const attrs = event.scheduleActivityTaskFailedEventAttributes;
-        const activityItem = {
-            type: 'activity',
-            name: attrs.activityType.name,
-            version: attrs.activityType.version,
-            canceled: false,
-            cancelRequested: false,
-            error: {
-                code: attrs.cause,
-                message: attrs.cause,
-            },
-            inProgress: false,
-            started: false,
-            success: false,
-        };
-        items.push(activityItem);
-    },
     ActivityTaskScheduled(event, state, items) {
         const attrs = event.activityTaskScheduledEventAttributes;
         const activityItem = {

--- a/src/events/types/child_workflow.js
+++ b/src/events/types/child_workflow.js
@@ -31,25 +31,6 @@ module.exports = {
         }
         state.childWorkflowItemsByWorkflowId[attrs.workflowId] = item;
     },
-    StartChildWorkflowExecutionFailed(event, state, items) {
-        // NOTE: There is no "initiated" event before this.
-        const attrs = event.startChildWorkflowExecutionFailedEventAttributes;
-        items.push({
-            type: 'child_workflow',
-            name: attrs.workflowType.name,
-            version: attrs.workflowType.version,
-            workflowId: attrs.workflowId,
-            canceled: false,
-            cancelRequested: false,
-            createdAt: new Date(event.eventTimestamp),
-            error: {
-                code: attrs.cause,
-                message: attrs.cause,
-            },
-            inProgress: false,
-            success: false,
-        });
-    },
     ChildWorkflowExecutionStarted() {
         // This is currently a no-op. Item creation is handled above.
     },

--- a/src/events/types/decision.js
+++ b/src/events/types/decision.js
@@ -8,11 +8,9 @@ function clearUnhandledEvents(event, state) {
     state.unhandledEvents = [];
 }
 
-// Currently we ignore decision task events.
-// If a case can be made for why the decider needs to know that it has been called, we can add.
 module.exports = {
     DecisionTaskCompleted: clearUnhandledEvents,
+    DecisionTaskTimedOut: clearUnhandledEvents,
     DecisionTaskScheduled: NOOP,
     DecisionTaskStarted: NOOP,
-    DecisionTaskTimedOut: clearUnhandledEvents,
 };

--- a/src/events/types/decision.js
+++ b/src/events/types/decision.js
@@ -1,10 +1,18 @@
 const NOOP = require('../../util/noop');
 
+// Undoes unhandled event tracking initiated by the distiller.
+// The idea here is that a decision task completing or timing out
+// marks an unhandled event as "handled".
+function clearUnhandledEvents(event, state) {
+    // eslint-disable-next-line no-param-reassign
+    state.unhandledEvents = [];
+}
+
 // Currently we ignore decision task events.
 // If a case can be made for why the decider needs to know that it has been called, we can add.
 module.exports = {
-    DecisionTaskCompleted: NOOP,
+    DecisionTaskCompleted: clearUnhandledEvents,
     DecisionTaskScheduled: NOOP,
     DecisionTaskStarted: NOOP,
-    DecisionTaskTimedOut: NOOP,
+    DecisionTaskTimedOut: clearUnhandledEvents,
 };

--- a/src/events/types/timer.js
+++ b/src/events/types/timer.js
@@ -19,23 +19,6 @@ module.exports = {
         }
         state.timerItemsByStartEventId[event.eventId] = timerItem;
     },
-    StartTimerFailed(event, state, items) {
-        const attrs = event.startTimerFailedEventAttributes;
-        const timerItem = {
-            type: 'timer',
-            canceled: false,
-            cancelRequested: false,
-            fired: false,
-            inProgress: false,
-            timerId: attrs.timerId,
-            error: {
-                code: attrs.cause,
-                message: attrs.cause,
-            },
-            started: false,
-        };
-        items.push(timerItem);
-    },
     TimerCanceled(event, state) {
         const attrs = event.timerCanceledEventAttributes;
 

--- a/test/integration/activities/index.js
+++ b/test/integration/activities/index.js
@@ -2,4 +2,5 @@
 
 module.exports = [
     require('./ping'),
+    require('./wait'),
 ];

--- a/test/integration/activities/wait.js
+++ b/test/integration/activities/wait.js
@@ -1,0 +1,12 @@
+module.exports = {
+    name: 'Wait',
+    versions: {
+        '1.0': {
+            func(seconds) {
+                return new Promise((resolve) => {
+                    setTimeout(resolve, seconds * 1000);
+                });
+            },
+        },
+    },
+};

--- a/test/integration/workflows/fail_to_continue_as_new.js
+++ b/test/integration/workflows/fail_to_continue_as_new.js
@@ -1,0 +1,43 @@
+// This workflow generates a "ContinueAsNewWorkflowExecutionFailed" event.
+module.exports = {
+    name: 'FailToContinueAsNew',
+    versions: {
+        '1.0': {
+            decider(items, availableDecisions) {
+                const {
+                    completeWorkflowExecution,
+                    continueAsNewWorkflowExecution,
+                    failWorkflowExecution,
+                    startActivity,
+                    startTimer,
+                } = availableDecisions;
+
+                if (items.length === 1) {
+                    return [
+                        startTimer('timer', 3),
+                        startActivity('Wait', 10),
+                    ];
+                }
+
+                const timer = items.find(i => i.type === 'timer');
+                const activity = items.find(i => i.type === 'activity');
+
+                if (timer.fired && !activity.inProgress) {
+                    return completeWorkflowExecution();
+                }
+
+                if (!activity.inProgress) {
+                    return failWorkflowExecution();
+                }
+
+                // while a timer is running, try to continue as new
+                // this should fail.
+                return continueAsNewWorkflowExecution();
+            },
+            settings: {
+                defaultExecutionStartToCloseTimeout: 60,
+                defaultTaskStartToCloseTimeout: 3,
+            },
+        },
+    },
+};

--- a/test/integration/workflows/index.js
+++ b/test/integration/workflows/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 module.exports = [
+    require('./fail_to_continue_as_new'),
     require('./fail_first_time'),
     require('./parent_with_fail_first_time'),
     require('./return_input'),

--- a/test/unit/events/activity.js
+++ b/test/unit/events/activity.js
@@ -1,4 +1,4 @@
-const { assert, expect } = require('chai');
+const { expect } = require('chai');
 
 const {
     distillSingleItem,

--- a/test/unit/events/activity.js
+++ b/test/unit/events/activity.js
@@ -1,7 +1,8 @@
-const { expect } = require('chai');
+const { assert, expect } = require('chai');
 
 const {
     distillSingleItem,
+    shouldBeUnhandled,
 } = require('./helpers');
 
 const scheduleFailedEvent = {
@@ -85,23 +86,7 @@ const timedOutEvent = {
 
 describe('Event Distillation - activity items', () => {
     it('ScheduleActivityTaskFailed', () => {
-        const item = distillSingleItem([
-            scheduleFailedEvent,
-        ]);
-        expect(item).to.deep.equal({
-            type: 'activity',
-            name: 'FooActivity',
-            version: '1.2',
-            error: {
-                code: 'ACTIVITY_TYPE_DOES_NOT_EXIST',
-                message: 'ACTIVITY_TYPE_DOES_NOT_EXIST',
-            },
-            canceled: false,
-            cancelRequested: false,
-            inProgress: false,
-            started: false,
-            success: false,
-        });
+        shouldBeUnhandled([scheduleFailedEvent]);
     });
 
     it('ActivityTaskScheduled', () => {

--- a/test/unit/events/child_workflow.js
+++ b/test/unit/events/child_workflow.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const {
     distillEventsIntoItems,
     distillSingleItem,
+    shouldBeUnhandled,
 } = require('./helpers');
 
 const initiatedEvent = {
@@ -159,24 +160,7 @@ describe('Event Distillation - child_workflow', () => {
         });
     });
     it('StartChildWorkflowExecutionFailed', () => {
-        const item = distillSingleItem([
-            startFailedEvent,
-        ]);
-        expect(item).to.deep.equal({
-            type: 'child_workflow',
-            name: 'TestChildWorkflow',
-            version: '1.0',
-            workflowId: 'TestChildWorkflow-1',
-            canceled: false,
-            cancelRequested: false,
-            createdAt: '2016-07-29T17:07:51.518Z',
-            error: {
-                code: 'DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED',
-                message: 'DEFAULT_EXECUTION_START_TO_CLOSE_TIMEOUT_UNDEFINED',
-            },
-            inProgress: false,
-            success: false,
-        });
+        shouldBeUnhandled([startFailedEvent]);
     });
     it('ChildWorkflowExecutionStarted', () => {
         const item = distillSingleItem([

--- a/test/unit/events/helpers.js
+++ b/test/unit/events/helpers.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const { assert, expect } = require('chai');
 
 const { distillEventsIntoItems } = require('../../../src/events');
 

--- a/test/unit/events/helpers.js
+++ b/test/unit/events/helpers.js
@@ -29,8 +29,20 @@ function distillSingleItem(events) {
     return checkDateProperties(items[0]);
 }
 
+function shouldBeUnhandled(events) {
+    try {
+        distillEventsIntoItems(events);
+        assert(false, 'Should have thrown EUNHANDLEDEVENT');
+    } catch (err) {
+        if (err.code !== 'EUNHANDLEDEVENT') {
+            throw err;
+        }
+    }
+}
+
 module.exports = {
     checkDateProperties,
     distillEventsIntoItems,
     distillSingleItem,
+    shouldBeUnhandled,
 };

--- a/test/unit/events/timer.js
+++ b/test/unit/events/timer.js
@@ -1,4 +1,4 @@
-const { assert, expect } = require('chai');
+const { expect } = require('chai');
 
 const {
     distillSingleItem,

--- a/test/unit/events/timer.js
+++ b/test/unit/events/timer.js
@@ -1,6 +1,9 @@
-const { expect } = require('chai');
+const { assert, expect } = require('chai');
 
-const { distillSingleItem } = require('./helpers');
+const {
+    distillSingleItem,
+    shouldBeUnhandled,
+} = require('./helpers');
 
 describe('Event Distillation - Timer Items', () => {
     it('TimerStarted', () => {
@@ -118,7 +121,7 @@ describe('Event Distillation - Timer Items', () => {
         });
     });
     it('CancelTimerFailed', () => {
-        const item = distillSingleItem([
+        shouldBeUnhandled([
             {
                 eventId: '12345',
                 eventType: 'TimerStarted',
@@ -137,15 +140,5 @@ describe('Event Distillation - Timer Items', () => {
                 },
             },
         ]);
-        expect(item).to.deep.equal({
-            type: 'timer',
-            timerId: 'foobarbaz',
-            canceled: false,
-            cancelRequested: false,
-            fired: false,
-            inProgress: true,
-            started: true,
-            startedAt: '2016-06-14T17:39:32.987Z',
-        });
     });
 });

--- a/test/unit/events/timer.js
+++ b/test/unit/events/timer.js
@@ -30,7 +30,7 @@ describe('Event Distillation - Timer Items', () => {
     });
 
     it('StartTimerFailed', () => {
-        const item = distillSingleItem([
+        shouldBeUnhandled([
             {
                 eventType: 'StartTimerFailed',
                 eventTimestamp: '2016-06-14T17:39:32.987Z',
@@ -40,19 +40,6 @@ describe('Event Distillation - Timer Items', () => {
                 },
             },
         ]);
-        expect(item).to.deep.equal({
-            type: 'timer',
-            timerId: 'foobarbaz',
-            canceled: false,
-            cancelRequested: false,
-            fired: false,
-            inProgress: false,
-            error: {
-                code: 'TIMER_ID_ALREADY_IN_USE',
-                message: 'TIMER_ID_ALREADY_IN_USE',
-            },
-            started: false,
-        });
     });
 
     it('TimerCanceled', () => {

--- a/test/unit/events/unhandled_event.js
+++ b/test/unit/events/unhandled_event.js
@@ -1,22 +1,42 @@
-const { expect } = require('chai');
+const { assert, expect } = require('chai');
 
 const { distillEventsIntoItems } = require('./helpers');
 
 describe('Unhandled event', () => {
-    it('does not die on unhandled event', () => {
-        const items = distillEventsIntoItems([
-            {
-                eventType: 'SomeWeirdEventNoOneHasHeardOf',
-            },
-        ]);
-        expect(items).to.deep.equal([]);
-    });
-    it('does not die on second unhandled event', () => {
-        const items = distillEventsIntoItems([
-            {
-                eventType: 'SomeWeirdEventNoOneHasHeardOf',
-            },
-        ]);
-        expect(items).to.deep.equal([]);
+    [
+        'DecisionTaskCompleted',
+        'DecisionTaskTimedOut',
+    ].forEach(eventType => {
+        it(`throws when coming after ${eventType}`, () => {
+            const events = [
+                {
+                    eventType,
+                },
+                {
+                    eventType: 'SomeWeirdEventNoOneHasHeardOf',
+                },
+            ];
+            try {
+                distillEventsIntoItems(events);
+                assert(false, 'should have thrown');
+            } catch (err) {
+                if (err.code !== 'EUNHANDLEDEVENT') {
+                    throw err;
+                }
+            }
+        });
+
+        it(`does not throw when coming before ${eventType}`, () => {
+            const events = [
+                {
+                    eventType: 'SomeWeirdEventNoOneHasHeardOf',
+                },
+                {
+                    eventType,
+                },
+            ];
+            const items = distillEventsIntoItems(events);
+            expect(items).to.deep.equal([]);
+        });
     });
 });


### PR DESCRIPTION
Sometimes SWF will insert an event into a workflow's history that I didn't think of adding support for in this library.  Before, worky-mcworkflowface would casually ignore the event, assuming it probably wasn't important anyway (otherwise I would've added support for it, right?). This leads to situations like the following:
1. Decider returns a `ContinueAsNewWorkflowExecution` decision.
2. SWF sends `ContinueAsNewWorkflowExecutionFailed` because the decider neglected to do some clean up it was supposed to do.
3. worky-mcworkflowface _ignores_ that event and re-executes the decider with the same items as the first execution.
4. GOTO 1

This leads to things like your decider trying to `ContinueAsNewWorkflowExecution` 1,000 times before someone notices and manually kills the workflow. Oh, and for good measure worky-mcworkflowface _logged_ that it encountered an unhandled `ContinueAsNewWorkflowExecutionFailed` event 1,000+999+998..+1 times, leading to a few extra GB of log traffic.

What can be done about this?

Right now, unrecognized events (i.e. ones I haven't thought of) usually arise for a few reasons:
1. AWS rate limiting
2. Incorrect AWS permissions or SWF domain setup
3. Decider bugs

Rate limiting would be helped by slowing down before retrying a failed operation. Bugs in decider code or problems with SWF configuration are not helped, but it'd be nice if we didn't go into an execution hellspiral when they occur.

**The Solution™**

When we **first see** an event we don't recognize, log that we saw it and crash the decider. The decision task will time out. The next time the decider is called, ignore the unrecognized event.

This effectively uses the decider's timeout interval (`defaultTaskStartToCloseTimeout`) to slow down the hellspiral. Not perfect, but better than before. An added benefit is that we can **remove** support for some more obscure events (i.e. `ScheduleActivityTaskFailed`) that tend only to happen as a result of decider bugs.

**Where this is going**

The core of this issue is that worky-mcworkflowface's `WorkflowItems` abstraction is leaky, and things like `ContinueAsNewWorkflowExecutionFailed` don't fit nicely within it. 

Adding an `onUnhandledEvent` callback is one possibility, but there's not much you can realistically do once you've received i.e. `ContinueAsNewWorkflowExecutionFailed`--the thing to do would've been not have whatever bug resulted in that in the first place.

Automatically failing the workflow is another possibility, but I'm not currently in favor of it because not all cases need be terminal (the rate limiting case may be one such instance).
